### PR TITLE
Added jsonb support

### DIFF
--- a/django_pgjson/lookups.py
+++ b/django_pgjson/lookups.py
@@ -61,3 +61,13 @@ class ArrayLengthLookup(Lookup):
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = lhs_params + rhs_params
         return 'json_array_length(%s) = %s' % (lhs, rhs), params
+
+
+class JsonBArrayLengthLookup(Lookup):
+    lookup_name = 'array_length'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'jsonb_array_length(%s) = %s' % (lhs, rhs), params

--- a/doc/doc.asciidoc
+++ b/doc/doc.asciidoc
@@ -3,6 +3,8 @@ django-pgjson documentation
 Andrey Antukh, <niwi@niwi.be>
 0.1.3, 2014-04-17
 
+Experimental jsonb support by Charl P. Botha <cpbotha@vxlabs.com>
+
 :toc:
 :numbered:
 
@@ -37,11 +39,13 @@ Supports
 
 - All json types. Including simple strings, floats, integers, booleans and null's.
 - Works well with python serialization.
+- Experimental: jsonb support in PostgreSQL >= 9.4
 
 Limitations
 ~~~~~~~~~~~
 
 - Only supports PostgreSQL >= 9.2
+- PostgeSQL 9.4 is required for jsonb.
 - No django admin support at this momment.
 - Limited set of django 1.7 lookups (will be improved with postgresql 9.4)
 
@@ -81,10 +85,12 @@ SOUTH_DATABASE_ADAPTERS = {'default': 'south.db.postgresql_psycopg2'}
 Usage
 -----
 
-The library provides this class:
+The library provides these classes:
 
 - `django_pgjson.fields.JsonField` +
   An ORM field which stores python dict in an json type column.
+- `django_pgjson.fields.JsonBField` + Same as above, but using the new jsonb
+  field in PostgreSQL >= 9.4
 
 
 Model setup

--- a/tests/pg_json_fields/models.py
+++ b/tests/pg_json_fields/models.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from django.db import models
-from django_pgjson.fields import JsonField
+from django_pgjson.fields import JsonField, JsonBField
 
 
 class TextModel(models.Model):
     data = JsonField()
+
+class TextModelB(models.Model):
+    data = JsonBField()

--- a/tests/pg_json_fields/tests.py
+++ b/tests/pg_json_fields/tests.py
@@ -6,99 +6,100 @@ from django.contrib.admin import AdminSite, ModelAdmin
 
 from django.test import TestCase
 from django.core.serializers import serialize, deserialize
-from django_pgjson.fields import JsonField
+from django_pgjson.fields import JsonField, JsonBField
 
-from .models import TextModel
+from .models import TextModel, TextModelB
 
 
 class JsonFieldTests(TestCase):
     def setUp(self):
-        TextModel.objects.all().delete()
+        self.model_class = TextModel
+        self.model_class.objects.all().delete()
 
     def test_empty_create(self):
-        instance = TextModel.objects.create(data={})
-        instance = TextModel.objects.get(pk=instance.pk)
+        instance = self.model_class.objects.create(data={})
+        instance = self.model_class.objects.get(pk=instance.pk)
         self.assertEqual(instance.data, {})
 
     def test_unicode(self):
-        obj = TextModel.objects.create(data={"list": ["Fóö", "Пример", "test"]})
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data={"list": ["Fóö", "Пример", "test"]})
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data["list"][1], "Пример")
 
     def test_array_serialization(self):
-        obj = TextModel.objects.create(data=["Fóö", "Пример", "test"])
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data=["Fóö", "Пример", "test"])
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data[1], "Пример")
 
     def test_primitives_bool(self):
-        obj = TextModel.objects.create(data=True)
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data=True)
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, True)
 
     def test_primitives_str(self):
-        obj = TextModel.objects.create(data="Foo")
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data="Foo")
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, "Foo")
 
     def test_primitives_int(self):
-        obj = TextModel.objects.create(data=3)
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data=3)
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, 3)
 
     def test_primitives_float(self):
-        obj = TextModel.objects.create(data=3.0)
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data=3.0)
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, 3.0)
 
     def test_primitives_null(self):
-        obj = TextModel.objects.create(data=None)
-        obj = TextModel.objects.get(pk=obj.pk)
+        obj = self.model_class.objects.create(data=None)
+        obj = self.model_class.objects.get(pk=obj.pk)
         self.assertEqual(obj.data, None)
 
     def test_key_lookup(self):
-        obj1 = TextModel.objects.create(data={"name": "foo"})
-        obj2 = TextModel.objects.create(data={"name": "bar"})
+        obj1 = self.model_class.objects.create(data={"name": "foo"})
+        obj2 = self.model_class.objects.create(data={"name": "bar"})
 
-        qs = TextModel.objects.filter(data__at_name="foo")
+        qs = self.model_class.objects.filter(data__at_name="foo")
         self.assertEqual(qs.count(), 1)
 
     def test_key_lookup2(self):
-        obj1 = TextModel.objects.create(data={"name": {"full": "foo"}})
-        obj2 = TextModel.objects.create(data={"name": {"full": "bar"}})
-        qs = TextModel.objects.filter(data__at_name={"full": "foo"})
+        obj1 = self.model_class.objects.create(data={"name": {"full": "foo"}})
+        obj2 = self.model_class.objects.create(data={"name": {"full": "bar"}})
+        qs = self.model_class.objects.filter(data__at_name={"full": "foo"})
         self.assertEqual(qs.count(), 1)
 
     def test_key_lookup3(self):
-        obj1 = TextModel.objects.create(data={"num": 2})
-        obj2 = TextModel.objects.create(data={"num": 3})
-        qs = TextModel.objects.filter(data__at_num=2)
+        obj1 = self.model_class.objects.create(data={"num": 2})
+        obj2 = self.model_class.objects.create(data={"num": 3})
+        qs = self.model_class.objects.filter(data__at_num=2)
         self.assertEqual(qs.count(), 1)
 
     def test_key_lookup4(self):
-        obj1 = TextModel.objects.create(data=[1,2,3,4])
-        obj2 = TextModel.objects.create(data=[5,6,7,8])
+        obj1 = self.model_class.objects.create(data=[1,2,3,4])
+        obj2 = self.model_class.objects.create(data=[5,6,7,8])
 
-        qs = TextModel.objects.filter(data__at_2=3)
+        qs = self.model_class.objects.filter(data__at_2=3)
         self.assertEqual(qs.count(), 1)
 
     def test_key_lookup5(self):
-        obj1 = TextModel.objects.create(data=[{"foo": 1}])
-        obj2 = TextModel.objects.create(data=[{"bar": 1}])
+        obj1 = self.model_class.objects.create(data=[{"foo": 1}])
+        obj2 = self.model_class.objects.create(data=[{"bar": 1}])
 
-        qs = TextModel.objects.filter(data__at_0={"foo": 1})
+        qs = self.model_class.objects.filter(data__at_0={"foo": 1})
         self.assertEqual(qs.count(), 1)
 
     def test_array_length(self):
-        obj1 = TextModel.objects.create(data=[1,2,3])
-        obj2 = TextModel.objects.create(data=[5,6,7,8,9])
+        obj1 = self.model_class.objects.create(data=[1,2,3])
+        obj2 = self.model_class.objects.create(data=[5,6,7,8,9])
 
-        qs = TextModel.objects.filter(data__array_length=3)
+        qs = self.model_class.objects.filter(data__array_length=3)
         self.assertEqual(qs.count(), 1)
 
     def test_value_to_string_serializes_correctly(self):
-        obj = TextModel.objects.create(data={"a": 1})
+        obj = self.model_class.objects.create(data={"a": 1})
 
-        serialized_obj = serialize('json', TextModel.objects.filter(pk=obj.pk))
+        serialized_obj = serialize('json', self.model_class.objects.filter(pk=obj.pk))
         obj.delete()
 
         deserialized_obj = list(deserialize('json', serialized_obj))[0]
@@ -110,9 +111,9 @@ class JsonFieldTests(TestCase):
         self.assertEqual(obj.data, {"a": 1})
 
     def test_to_python_serializes_xml_correctly(self):
-        obj = TextModel.objects.create(data={"a": 0.2})
+        obj = self.model_class.objects.create(data={"a": 0.2})
 
-        serialized_obj = serialize('xml', TextModel.objects.filter(pk=obj.pk))
+        serialized_obj = serialize('xml', self.model_class.objects.filter(pk=obj.pk))
 
         obj.delete()
         deserialized_obj = list(deserialize('xml', serialized_obj))[0]
@@ -131,6 +132,10 @@ class JsonFieldTests(TestCase):
         form_field = model_field.formfield(form_class=FakeFieldClass)
         self.assertIsInstance(form_field, FakeFieldClass)
 
+class JsonBFieldTests(JsonFieldTests):
+    def setUp(self):
+        self.model_class = TextModelB
+
 
 #class ArrayFormFieldTests(TestCase):
 #    def test_regular_forms(self):
@@ -146,7 +151,7 @@ class JsonFieldTests(TestCase):
 #
 #    def test_admin_forms(self):
 #        site = AdminSite()
-#        model_admin = ModelAdmin(TextModel, site)
+#        model_admin = ModelAdmin(self.model_class, site)
 #        form_clazz = model_admin.get_form(None)
 #        form_instance = form_clazz()
 #


### PR DESCRIPTION
Added jsonb support, at the same level of functionality as the current json support. All json tests are running successfully on jsonb with Django 1.7rc1 and PostgreSQL 9.4 beta.

Next steps: Look into adding transforms / lookups so that we can use more of the special GiN-accelerated jsonb operators, such as containment `@>`, existence `?` and so on. See http://www.postgresql.org/docs/9.4/static/datatype-json.html
