### PR TITLE
Fix 1 of 2 for #12

### DIFF
--- a/django_pgjson/lookups.py
+++ b/django_pgjson/lookups.py
@@ -2,10 +2,13 @@
 
 from django.utils.functional import cached_property
 from django.utils import six
-from django.db.models import Transform, Lookup
+from django.db.models import Transform, Lookup, CharField
 
 
 class KeyTransform(Transform):
+
+    output_field = CharField()
+
     def __init__(self, key, base_field, *args, **kwargs):
         super(KeyTransform, self).__init__(*args, **kwargs)
         try:

--- a/tests/pg_json_fields/tests.py
+++ b/tests/pg_json_fields/tests.py
@@ -119,11 +119,11 @@ if django.VERSION[:2] > (1, 6):
             qs = self.model_class.objects.filter(data__at_name="foo")
             self.assertEqual(qs.count(), 1)
 
-        def test_key_lookup2(self):
-            obj1 = self.model_class.objects.create(data={"name": {"full": "foo"}})
-            obj2 = self.model_class.objects.create(data={"name": {"full": "bar"}})
-            qs = self.model_class.objects.filter(data__at_name={"full": "foo"})
-            self.assertEqual(qs.count(), 1)
+        # def test_key_lookup2(self):
+        #     obj1 = self.model_class.objects.create(data={"name": {"full": "foo"}})
+        #     obj2 = self.model_class.objects.create(data={"name": {"full": "bar"}})
+        #     qs = self.model_class.objects.filter(data__at_name={"full": "foo"})
+        #     self.assertEqual(qs.count(), 1)
 
         def test_key_lookup3(self):
             obj1 = self.model_class.objects.create(data={"num": 2})
@@ -138,12 +138,19 @@ if django.VERSION[:2] > (1, 6):
             qs = self.model_class.objects.filter(data__at_2=3)
             self.assertEqual(qs.count(), 1)
 
-        def test_key_lookup5(self):
-            obj1 = self.model_class.objects.create(data=[{"foo": 1}])
-            obj2 = self.model_class.objects.create(data=[{"bar": 1}])
+        # def test_key_lookup5(self):
+        #     obj1 = self.model_class.objects.create(data=[{"foo": 1}])
+        #     obj2 = self.model_class.objects.create(data=[{"bar": 1}])
+        #
+        #     qs = self.model_class.objects.filter(data__at_0={"foo": 1})
+        #     self.assertEqual(qs.count(), 1)
 
-            qs = self.model_class.objects.filter(data__at_0={"foo": 1})
-            self.assertEqual(qs.count(), 1)
+        def test_key_lookup_in(self):
+            obj1 = self.model_class.objects.create(data={"name": "foo"})
+            obj2 = self.model_class.objects.create(data={"name": "bar"})
+
+            qs = self.model_class.objects.filter(data__at_name__in=["foo", "bar"])
+            self.assertEqual(qs.count(), 2)
 
         def test_array_length(self):
             obj1 = self.model_class.objects.create(data=[1,2,3])


### PR DESCRIPTION
The output field of the `KeyTransform` is a `CharField`

The `->>` operator always evaluates to a textual representation of the JSON value, so the key transform results in a char-like value

Two tests fail and have been commented out: comparisons like `.filter(field__at_key={ "some": [ "complex", { "json": construct" } ] })` aren't really possible for JSON fields; that would compare the textual JSON serialization of the value stored in Postgres against the textual JSON serialization produced by Python's `json.dumps`. Those are definitely _not_ guaranteed to match, especially with regard to dictionary key order. The test cases are so trivial that they pass by chance, but might lead people to believe they can do things with JSON fields that they can't really do.