### PR TITLE
Fix 2 of 2 for #12

### DIFF
--- a/django_pgjson/lookups.py
+++ b/django_pgjson/lookups.py
@@ -19,9 +19,9 @@ class KeyTransform(Transform):
         lhs, params = qn.compile(self.lhs)
 
         if isinstance(self.key, int):
-            return "%s->>%s" % (lhs, self.key), params
+            return "(%s->>%s)" % (lhs, self.key), params
 
-        return "%s->>'%s'" % (lhs, self.key), params
+        return "(%s->>'%s')" % (lhs, self.key), params
 
     @cached_property
     def output_type(self):

--- a/tests/pg_json_fields/tests.py
+++ b/tests/pg_json_fields/tests.py
@@ -145,6 +145,34 @@ if django.VERSION[:2] > (1, 6):
             qs = self.model_class.objects.filter(data__at_0={"foo": 1})
             self.assertEqual(qs.count(), 1)
 
+        def test_key_lookup_isnull1(self):
+            obj1 = self.model_class.objects.create(data={"name": "foo"})
+            obj2 = self.model_class.objects.create(data={"name": "bar"})
+
+            qs = self.model_class.objects.filter(data__at_name__isnull=True)
+            self.assertEqual(qs.count(), 0)
+
+        def test_key_lookup_isnull2(self):
+            obj1 = self.model_class.objects.create(data={"name": "foo"})
+            obj2 = self.model_class.objects.create(data={"name": "bar"})
+
+            qs = self.model_class.objects.filter(data__at_name__isnull=False)
+            self.assertEqual(qs.count(), 2)
+
+        def test_key_lookup_isnull3(self):
+            obj1 = self.model_class.objects.create(data={"name": "foo"})
+            obj2 = self.model_class.objects.create(data={"name": "bar"})
+
+            qs = self.model_class.objects.filter(data__at_notfound__isnull=True)
+            self.assertEqual(qs.count(), 2)
+
+        def test_key_lookup_isnull4(self):
+            obj1 = self.model_class.objects.create(data={"name": "foo"})
+            obj2 = self.model_class.objects.create(data={"name": "bar"})
+
+            qs = self.model_class.objects.filter(data__at_notfound__isnull=False)
+            self.assertEqual(qs.count(), 0)
+
         def test_array_length(self):
             obj1 = self.model_class.objects.create(data=[1,2,3])
             obj2 = self.model_class.objects.create(data=[5,6,7,8,9])


### PR DESCRIPTION
Fix operator precedence

The `->>` operator has a very low precedence, so expressions like `field->>'key' IS NULL` actually evaluate as `field->>('key' IS NULL)` which does not make much sense