### PR TITLE
Pass `json_dump_args` to json.dumps

### DIFF
--- a/django_pgjson/fields.py
+++ b/django_pgjson/fields.py
@@ -70,8 +70,8 @@ class JsonField(six.with_metaclass(models.SubfieldBase, models.Field)):
         return value
 
     def formfield(self, **kwargs):
-        defaults = {'form_class': jsonFormField(indent=self.indent,
-                                                sort_keys=self.sort_keys)}
+        defaults = {'form_class': jsonFormField(indent_=self.indent,
+                                                sort_keys_=self.sort_keys)}
         defaults.update(kwargs)
         return super(JsonField, self).formfield(**defaults)
 
@@ -147,11 +147,11 @@ if django.get_version() >= '1.7':
 
 # return a class of JsonFormField
 
-def jsonFormField(indent=None, sort_keys=False):
+def jsonFormField(indent_=None, sort_keys_=False):
     class JsonFormField(forms.CharField):
 
-        indent = indent
-        sort_keys = sort_keys
+        indent = indent_
+        sort_keys = sort_keys_
 
         widget = forms.Textarea
 

--- a/django_pgjson/fields.py
+++ b/django_pgjson/fields.py
@@ -70,8 +70,8 @@ class JsonField(six.with_metaclass(models.SubfieldBase, models.Field)):
         return value
 
     def formfield(self, **kwargs):
-        defaults = {'form_class': jsonFormField(indent_=self.indent,
-                                                sort_keys_=self.sort_keys)}
+        defaults = {'form_class': jsonFormField(indent=self.indent,
+                                                sort_keys=self.sort_keys)}
         defaults.update(kwargs)
         return super(JsonField, self).formfield(**defaults)
 
@@ -147,11 +147,11 @@ if django.get_version() >= '1.7':
 
 # return a class of JsonFormField
 
-def jsonFormField(indent_=None, sort_keys_=False):
+def jsonFormField(indent=None, sort_keys=False):
     class JsonFormField(forms.CharField):
 
-        indent = indent_
-        sort_keys = sort_keys_
+        indent = indent
+        sort_keys = sort_keys
 
         widget = forms.Textarea
 

--- a/doc/doc.asciidoc
+++ b/doc/doc.asciidoc
@@ -197,6 +197,21 @@ We will implement support for more of the jsonb operators in the near future.
 See http://www.postgresql.org/docs/9.4/static/datatype-json.html for more
 information on what's possible, and feel free to send a pull request.
 
+Formatting JSON output
+^^^^^^^^^^^^^^^^^^^^^^
+
+To control the format of serialized JSON, you may define a `json_dump_args`
+dict for a field.  Its contents will be passed as arguments to `json.dumps`.
+
+----
+
+    data = JsonField(json_dump_args={'indent': 2, 'sort_keys': True})
+    
+----
+
+See https://docs.python.org/3/library/json.html#json.dumps
+for accepted arguments.
+
 Developers
 ----------
 

--- a/tests/pg_json_fields/migrations/0003_textmodelwithindent.py
+++ b/tests/pg_json_fields/migrations/0003_textmodelwithindent.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django_pgjson.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pg_json_fields', '0002_textmodelwithdefault'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TextModelWithIndent',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
+                ('data', django_pgjson.fields.JsonField()),
+            ],
+        ),
+    ]

--- a/tests/pg_json_fields/models.py
+++ b/tests/pg_json_fields/models.py
@@ -14,4 +14,4 @@ class TextModelWithDefault(models.Model):
     data = JsonField(blank=True, default={})
 
 class TextModelWithIndent(models.Model):
-    data = JsonField(indent=2)
+    data = JsonField(json_dump_args={'indent': 2})

--- a/tests/pg_json_fields/models.py
+++ b/tests/pg_json_fields/models.py
@@ -12,3 +12,6 @@ class TextModelB(models.Model):
 
 class TextModelWithDefault(models.Model):
     data = JsonField(blank=True, default={})
+
+class TextModelWithIndent(models.Model):
+    data = JsonField(indent=2)

--- a/tests/pg_json_fields/tests.py
+++ b/tests/pg_json_fields/tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+import json
 
 import django
 from django.contrib.admin import AdminSite, ModelAdmin
@@ -10,6 +11,7 @@ from django.core.serializers import serialize, deserialize
 from django_pgjson.fields import JsonField, JsonBField
 
 from .models import TextModel, TextModelB, TextModelWithDefault
+from .models import TextModelWithIndent
 
 
 class JsonFieldTests(TestCase):
@@ -187,6 +189,13 @@ if django.VERSION[:2] > (1, 6):
             qs = self.model_class.objects.filter(data__array_length=3)
             self.assertEqual(qs.count(), 1)
 
+        def test_indent(self):
+            obj1 = TextModelWithIndent.objects.create(
+                data={"name": "foo", "bar": {"baz": 1}})
+            qs = TextModelWithIndent.objects.filter(data__at_name="foo")
+            serialized_obj1 = serialize('json', qs)
+            self.assertIn('\n  "name":',
+                          json.loads(serialized_obj1)[0]['fields']['data'])
 
 class JsonBFieldTests(JsonFieldTests):
     def setUp(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,8 +10,8 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'test',
-        'USER': '',
-        'PASSWORD': '',
+        'USER': 'test',
+        'PASSWORD': 'test',
         'HOST': 'localhost',
         'PORT': '',
     }


### PR DESCRIPTION
JsonFields now accept a dict of arguments (`json_dump_args`) which will be passed through to `json.dumps`.  This allows formatting the serialized output with `indent`, `sort_keys`, etc.